### PR TITLE
Fix M5Stack Atom Echo BLE advertising and connection issues

### DIFF
--- a/omiGlass/firmware-m5stack-atom-echo/src/app.cpp
+++ b/omiGlass/firmware-m5stack-atom-echo/src/app.cpp
@@ -53,10 +53,12 @@ bool audioDataUploading = false;
 // Main OMI Service - using config.h UUIDs
 static BLEUUID serviceUUID(OMI_SERVICE_UUID);
 static BLEUUID audioDataUUID(AUDIO_DATA_UUID);
+static BLEUUID audioCodecUUID(AUDIO_CODEC_UUID);
 static BLEUUID audioControlUUID(AUDIO_CONTROL_UUID);
 
 // BLE Characteristics
 BLECharacteristic *audioDataCharacteristic;
+BLECharacteristic *audioCodecCharacteristic;
 BLECharacteristic *audioControlCharacteristic;
 BLECharacteristic *batteryLevelCharacteristic;
 
@@ -210,12 +212,20 @@ void setupBLE() {
     audioDataCharacteristic = pService->createCharacteristic(
         audioDataUUID,
         BLECharacteristic::PROPERTY_READ |
-        BLECharacteristic::PROPERTY_WRITE |
         BLECharacteristic::PROPERTY_NOTIFY
     );
     audioDataCharacteristic->addDescriptor(new BLE2902());
     
-    // Audio Control Characteristic
+    // Audio Codec Characteristic (read-only, returns codec type)
+    audioCodecCharacteristic = pService->createCharacteristic(
+        audioCodecUUID,
+        BLECharacteristic::PROPERTY_READ
+    );
+    // Set codec type: 0=PCM16, 1=PCM8, 20=OPUS (we use PCM16)
+    uint8_t codecType = 0; // PCM16
+    audioCodecCharacteristic->setValue(&codecType, 1);
+    
+    // Audio Control Characteristic (new UUID for control commands)
     audioControlCharacteristic = pService->createCharacteristic(
         audioControlUUID,
         BLECharacteristic::PROPERTY_READ |

--- a/omiGlass/firmware-m5stack-atom-echo/src/config.h
+++ b/omiGlass/firmware-m5stack-atom-echo/src/config.h
@@ -11,7 +11,7 @@
 // =============================================================================
 // DEVICE CONFIGURATION
 // =============================================================================
-#define BLE_DEVICE_NAME "OMI Atom Echo"
+#define BLE_DEVICE_NAME "Omi"
 #define FIRMWARE_VERSION_STRING "1.0.0"
 #define HARDWARE_REVISION "ESP32-PICO-v1.0"
 #define MANUFACTURER_NAME "Based Hardware"
@@ -120,7 +120,8 @@ typedef enum {
 // =============================================================================
 #define OMI_SERVICE_UUID "19B10000-E8F2-537E-4F6C-D104768A1214"
 #define AUDIO_DATA_UUID "19B10001-E8F2-537E-4F6C-D104768A1214"
-#define AUDIO_CONTROL_UUID "19B10002-E8F2-537E-4F6C-D104768A1214"
+#define AUDIO_CODEC_UUID "19B10002-E8F2-537E-4F6C-D104768A1214"
+#define AUDIO_CONTROL_UUID "19B10004-E8F2-537E-4F6C-D104768A1214"
 
 // Battery Service UUID
 #define BATTERY_SERVICE_UUID (uint16_t)0x180F


### PR DESCRIPTION
Resolve device discovery and connection problems with the Omi app

## Summary
- Fix device name from "OMI Atom Echo" to "Omi" for proper app discovery
- Restore audio codec characteristic (19B10002) to read-only codec information
- Add new audio control characteristic (19B10004) for control commands
- Fix audio data characteristic properties to match original specification
- Ensure full BLE protocol compatibility with Omi app

## Issues Resolved
- ❌ Omi app cannot detect M5Stack Atom Echo device
- ❌ BLE connection fails after device discovery
- ❌ Audio control and codec characteristics semantic mismatch

## Test Plan
- [ ] Build and flash firmware to M5Stack Atom Echo
- [ ] Verify device appears as "Omi" in app scan results
- [ ] Test successful BLE connection from Omi app
- [ ] Verify audio recording and streaming functionality
- [ ] Test control commands (start/stop recording)

🤖 Generated with [Claude Code](https://claude.ai/code)) • [`claude/issue-2-20250728-1742`](https://github.com/madcodrr/omi/tree/claude/issue-2-20250728-1742